### PR TITLE
fix error and double disconnected actions on stopSignalRHub action

### DIFF
--- a/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
+++ b/src/projects/ngrx-signalr-core/src/lib/SignalRHub.ts
@@ -51,7 +51,9 @@ export class SignalRHub implements ISignalRHub {
       );
 
       this._connection.onclose((error) => {
-        this._errorSubject.next(error);
+        if (error) {
+          this._errorSubject.next(error);
+        }
         this._stateSubject.next(disconnected);
       });
       this._connection.onreconnecting(() => {
@@ -90,7 +92,6 @@ export class SignalRHub implements ISignalRHub {
       .stop()
       .then((_) => {
         this._stopSubject.next();
-        this._stateSubject.next(disconnected);
       })
       .catch((error) => this._errorSubject.next(error));
 


### PR DESCRIPTION
Fixes issue #26

I propose changing `this._errorSubject.next(error);` to `if (error) { this._errorSubject.next(error); }` due to fact `this._connection.onclose` emits undefined in case of gracefully stopped connection and instance of Error while the error occurred.
This eliminates throw of `@ngrx/signalr/stopHub` action on `stopSignalRHub(hub)`.

To fix double `@ngrx/signalr/disconnected` I propose removing `this._stateSubject.next(disconnected);` because the `this._stateSubject.next` would be called in `this._connection.onclose` after the connection stops.

